### PR TITLE
add scc, animation

### DIFF
--- a/src/sass/base/_base-styles.scss
+++ b/src/sass/base/_base-styles.scss
@@ -23,3 +23,18 @@ body {
     padding-right: 16px;
   }
 }
+
+// Анимация-Gallery
+@keyframes myImgAnimation {
+
+  0% { opacity: 0; }
+
+  12.12% { opacity: 1; }
+
+  35.35% { opacity: 1; }
+
+  45.45% { opacity: 0; }
+
+  100% { opacity: 0; }
+
+}

--- a/src/sass/components/_gallery.scss
+++ b/src/sass/components/_gallery.scss
@@ -1,0 +1,46 @@
+.gallery {
+    @include section(60px, 60px);
+  
+    @media screen and (min-width: 1200px) {
+      padding-left: 93px;
+      padding-right: 93px;
+    }
+    &__set {
+      position: relative;
+      width: 100%;
+    }
+  
+    &__img {
+      position: absolute;
+      width: 100%;
+      left: 0;
+      right: 0;
+  
+      border-radius: 7px;
+  
+      @media screen and (min-width: 768px) {
+        border-radius: 18px;
+      }
+  
+      @media screen and (min-width: 1200px) {
+        border-radius: 24px;
+      }
+  
+      opacity: 0;
+      animation-name: myImgAnimation;
+      animation-duration: 10s;
+      animation-iteration-count: infinite;
+  
+      &:nth-child(1) {
+        animation-delay: 0s;
+      }
+  
+      &:nth-child(2) {
+        animation-delay: 4s;
+      }
+  
+      &:nth-child(3) {
+        animation-delay: 7s;
+      }
+    }
+  }


### PR DESCRIPTION
Добавлены CSS-стили (mobile, tablet, desktop). Использованы фото (ссылки) из интернета для примера работы анимированного слайдшоу на CSS. В base добавлено правило @Keyframes - устанавливает ключевые кадры при анимации элемента.